### PR TITLE
Use systemmonitor dataengine

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -39,35 +39,15 @@ Item
         property color overheatColor: Qt.rgba(1, 0, 0, 1)
     }
 
-    Timer
+    PlasmaCore.DataSource
     {
-        id: tmrTemperature
-        running: true
-        repeat: true
+        id: temperatureData
+        engine: "systemmonitor"
+        connectedSources: ["acpi/Thermal_Zone/0/Temperature"]
         interval: 500
 
-        property string temperature: ""
-
-        onTriggered:
-        {
-            tmrTemperature.temperature = ""
-            // /sys/bus/platform/devices/coretemp.0/temp2_input     ex: 47000
-            // /sys/bus/acpi/devices/LNXTHERM:00/thermal_zone/temp  ex: 47000
-            var temperatureRead = plasmoid.getUrl("/sys/class/thermal/thermal_zone0/temp");
-
-            temperatureRead.data.connect(readTemperature);
-            temperatureRead.finished.connect(readTemperatureFinished);
-        }
-
-        function readTemperature(job, data)
-        {
-            if (data.length)
-                tmrTemperature.temperature += data.toUtf8()
-        }
-
-        function readTemperatureFinished(job)
-        {
-            txtTemperature.temperature = parseInt(tmrTemperature.temperature, 10) / 1e3
+        onNewData:{
+            txtTemperature.temperature = data.value
             txtTemperature.color = txtTemperature.temperature >= txtTemperature.overheatLevel? txtTemperature.overheatColor: theme.textColor
         }
     }

--- a/metadata.desktop
+++ b/metadata.desktop
@@ -2,12 +2,11 @@
 Name=CPU temperature meter
 Comment=CPU temperature meter
 Type=Service
-ServiceTypes=Plasma/Applet,Plasma/PopupApplet
 Icon=utilities-system-monitor
 
 X-Plasma-API=declarativeappletscript
 X-Plasma-MainScript=ui/main.qml
-X-Plasma-RequiredExtensions=LocalIO
+X-KDE-ServiceTypes=Plasma/Applet,Plasma/PopupApplet
 X-KDE-PluginInfo-Author=Gonzalo Exequiel Pedone
 X-KDE-PluginInfo-Email=hipersayan.x@gmail.com
 X-KDE-PluginInfo-Name=cpu-temperature-meter


### PR DESCRIPTION
Use the already available dataengine instead of manually reading the temperature from a file.
This is a noticeable optimisation, especially on idle systems.
(plasmoid.getUrl creates a temporary file, reads from it and removes it. This causes quite some overhead from QFile if run 2 times a second)
